### PR TITLE
Update builder.py

### DIFF
--- a/Payload_Type/poseidon/mythic/agent_functions/builder.py
+++ b/Payload_Type/poseidon/mythic/agent_functions/builder.py
@@ -150,9 +150,12 @@ class Poseidon(PayloadType):
                 if debug:
                     resp.build_message += f"\n[BUILD]{command}\n"
             if stderr:
-                resp.build_stderr += f"\n[STDERR]\n{stderr.decode()}"
-                if debug:
-                    resp.build_stderr += f"\n[BUILD]{command}\n"
+                if self.get_parameter("garble"):
+                    resp.build_stderr += "\n[STDERR]\nGarble stderr is way too long. Skipping."
+                else:
+                    resp.build_stderr += f"\n[STDERR]\n{stderr.decode()}"
+                    if debug:
+                        resp.build_stderr += f"\n[BUILD]{command}\n"
 
             # default build mode
             if self.get_parameter("mode") == "default":


### PR DESCRIPTION
Skip adding stderr to resp if garble is used as it generates megabytes of text output and causes the mythic API to fail.

```
websockets.exceptions.PayloadTooBig: over size limit (2496193 > 1048576 bytes)
```

Without this change, it is not possible to build poseidon with the Mythic API.